### PR TITLE
test(nydus): add hello world test

### DIFF
--- a/src/nydus/src/lib.rs
+++ b/src/nydus/src/lib.rs
@@ -5,3 +5,11 @@ mod types;
 pub use client::NydusClient;
 pub use error::Error;
 pub use types::*;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn hello_world() {
+        assert_eq!("hello", "hello");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `hello_world` unit test to `src/nydus/src/lib.rs`

## Why
Establishes a baseline test in the nydus crate to verify the test harness runs correctly for this module.

## Test plan
- [ ] `cargo test -p nydus hello_world` passes
- [ ] `buck2 test root//src/nydus:nydus` passes (when Buck2 test target exists)