### PR TITLE
test(nydus): add hello world test

### DIFF
--- a/src/nydus/src/lib.rs
+++ b/src/nydus/src/lib.rs
@@ -5,3 +5,11 @@ mod types;
 pub use client::NydusClient;
 pub use error::Error;
 pub use types::*;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn hello_world() {
+        assert_eq!("hello", "hello");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a simple `hello_world` test to the `nydus` crate's `lib.rs`
- Verifies the test module wires up correctly alongside existing tests in `client.rs`

## Test plan
- [ ] `cargo test` in `src/nydus/` passes with the new `tests::hello_world` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)