### PR TITLE
review: code review for PR #14 webhook notifier

### DIFF
--- a/docs/reviews/2026-04-01-pr-14.md
+++ b/docs/reviews/2026-04-01-pr-14.md
@@ -1,0 +1,185 @@
+# Code Review: PR #14 — feat(queen): add webhook notifier
+
+**PR:** https://github.com/rsJames-ttrpg/kerrigan/pull/14
+**Author:** rsJames-ttrpg
+**Reviewer:** Claude Code Drone
+**Date:** 2026-04-01
+**Verdict:** Request Changes (2 blocking issues, several minor)
+
+---
+
+## Summary
+
+Adds a `WebhookNotifier` implementing the `Notifier` trait, POSTing JSON to any HTTP
+endpoint on filtered Queen events. Expands `NotificationConfig` with `url`, `token`,
+`events`, and `body` fields. Token supports `env:VAR_NAME` injection. Wires backend
+selection in `main.rs`. Adds 4 config tests and 11 webhook unit tests. The implementation
+closely follows the plan in `docs/plans/2026-04-01-webhook-notifier.md`.
+
+The structure, logic, and test approach are all solid. Two issues require fixes before
+merge; remaining notes are suggestions.
+
+---
+
+## Issues
+
+### [BLOCKING] JSON injection in body template rendering
+
+**File:** `src/queen/src/notifier/webhook.rs`, `render_template` + `notify`
+
+`render_template` does naive string substitution into a JSON template. Placeholder values
+are not JSON-escaped before insertion, so any value containing `"` (double-quote),
+`\` (backslash), or newlines will produce invalid JSON.
+
+This is a real-world failure mode: Rust error messages routinely contain double-quotes
+(e.g., `parse error: expected "}"`). When such an error reaches
+`QueenEvent::DroneFailed { error: ... }`, the rendered body will be invalid JSON, the
+webhook endpoint will reject the request with a 4xx, and the notification is silently
+dropped (only a `warn!` log).
+
+**Example:**
+```
+template:  {"text":"{{message}}"}
+message:   Drone failed for job abc: expected "}"
+rendered:  {"text":"Drone failed for job abc: expected "}"}   ← invalid JSON
+```
+
+**Fix:** After rendering the template, validate that the output is valid JSON using
+`serde_json::from_str::<serde_json::Value>`. If invalid, log a warning with the raw
+message and skip the send (or fall back to a sanitized payload). A better fix is to build
+the body as a `serde_json::Value`, substitute into string fields only (JSON-escaped), and
+re-serialize — but this requires a different template model.
+
+The quickest safe fix for v1: validate the rendered string before sending and warn loudly
+on malformed JSON instead of sending corrupt data:
+
+```rust
+// in notify(), after render_template:
+if serde_json::from_str::<serde_json::Value>(&body).is_err() {
+    tracing::warn!(event_type = et, "webhook body template produced invalid JSON, skipping");
+    return;
+}
+```
+
+---
+
+### [BLOCKING] Thread-unsafe environment variable mutation in tests
+
+**File:** `src/queen/src/notifier/webhook.rs:396-408` (`test_from_config_env_token`)
+
+`std::env::set_var` / `remove_var` are not thread-safe in multi-threaded Rust test
+environments. Cargo runs tests in parallel threads by default. If another test reads or
+modifies the environment concurrently, this is undefined behavior. Rustc nightly already
+emits a lint for this (`set_var` is `unsafe` in nightly/edition 2024 under discussion).
+
+**Fix:** Either:
+1. Use `std::env::set_var` inside `unsafe {}` with an annotation explaining the risk, and
+   add `#[serial_test::serial]` (or the equivalent) to serialize env-mutating tests.
+2. Refactor `from_config` to accept an env-lookup function: `fn(var: &str) -> Option<String>`
+   (defaulting to `std::env::var`), making env access injectable for tests.
+3. Use a scoped env-var crate (`temp-env`) that provides safe, scoped overrides.
+
+Option 2 (injectable env lookup) is cleanest and makes the code more testable without any
+synchronization overhead.
+
+---
+
+### [MINOR] Duplicated `VALID_EVENTS` list
+
+**Files:** `src/queen/src/notifier/webhook.rs:146-157`,
+`src/queen/src/config.rs:179-190`
+
+The list of valid event names is defined twice: once as a `const` in `webhook.rs` and once
+as an inline array inside `Config::validate()` in `config.rs`. If a new `QueenEvent`
+variant is added, both lists must be updated — one is easy to miss.
+
+`VALID_EVENTS` should be the single source of truth. Export it from `webhook.rs` (or a
+shared location) and use it in `config.rs::validate()`:
+
+```rust
+// In config.rs validate():
+use crate::notifier::webhook::VALID_EVENTS;
+// ...
+if !VALID_EVENTS.contains(&e.as_str()) { ... }
+```
+
+This also ensures Config validation and WebhookNotifier accept exactly the same event set.
+
+---
+
+### [MINOR] Incomplete `build_placeholders` test coverage
+
+**File:** `src/queen/src/notifier/webhook.rs` (test module)
+
+Tests cover `DroneFailed`, `DroneStalled`, and `DroneTimedOut`. The other 7 event types
+(`DroneCompleted`, `DroneSpawned`, `HatcheryRegistered`, `AuthRequested`, `CreepStarted`,
+`CreepDied`, `ShuttingDown`) are not tested.
+
+Not blocking — the pattern is clear and consistent — but adding tests for at least the
+events with non-trivial placeholder sets (`DroneCompleted`, `HatcheryRegistered`,
+`AuthRequested`) would increase confidence and guard against future regressions.
+
+---
+
+### [MINOR] Startup-time token resolution not documented
+
+**File:** `src/queen/src/notifier/webhook.rs:168-180`
+
+The `env:VAR_NAME` token is resolved once at startup in `from_config`. This means if the
+token is rotated, the service must restart to pick up the new value. This is a reasonable
+v1 design, but it should be documented in `hatchery.toml` alongside the commented example:
+
+```toml
+# Note: env: tokens are resolved at startup. Restart queen to pick up token rotation.
+```
+
+---
+
+### [SUGGESTION] No URL scheme validation
+
+**File:** `src/queen/src/config.rs:174-176`
+
+The webhook URL accepts any string. A typo like `htps://...` passes validation and will
+produce a runtime error on first use. Consider a basic check in `validate()`:
+
+```rust
+if let Some(url) = &self.notifications.url {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        anyhow::bail!("notifications.url must start with http:// or https://");
+    }
+}
+```
+
+---
+
+### [SUGGESTION] `test_from_config_valid` accesses private fields
+
+**File:** `src/queen/src/notifier/webhook.rs:354-368`
+
+The test accesses `notifier.url`, `notifier.token`, `notifier.events` directly. These
+fields are not `pub`, so this only works because the test is in the same module. This is
+fine, but worth noting — the test is tightly coupled to the struct layout. No action
+required.
+
+---
+
+## What's Good
+
+- **Clean architecture:** `WebhookNotifier` is a self-contained impl of the `Notifier`
+  trait with no coupling to other actors beyond `config.rs`.
+- **Config validation at startup:** `Config::validate()` catches misconfigured webhook
+  backends before any attempt to use them. Errors are actionable.
+- **Failure handling:** Network errors and non-2xx responses are logged at `warn` level and
+  do not panic or crash the process. Notifications are best-effort, which is correct.
+- **Token injection:** The `env:VAR_NAME` pattern keeps secrets out of config files.
+- **Good test coverage for `from_config`:** All the important constructor paths are tested
+  (valid, missing URL, invalid event, env token, missing env token, default events).
+- **Plan adherence:** Implementation matches the plan exactly.
+
+---
+
+## Test Execution Note
+
+Tests could not be executed in this review environment (no `python3` → Buck2 hermetic Rust
+toolchain cannot link). Logic review was performed by reading the code directly. The test
+cases themselves look correct.


### PR DESCRIPTION
## Summary

- Adds `docs/reviews/2026-04-01-pr-14.md` with a thorough code review of PR #14 (feat(queen): add webhook notifier)
- Identifies 2 blocking issues, 2 minor issues, and 2 suggestions
- Review also posted as a comment on PR #14

## Key Findings

**Blocking:**
1. **JSON injection** — `render_template` does naive string substitution without JSON-escaping; error messages containing `"` produce invalid JSON bodies that silently fail
2. **Thread-unsafe `env::set_var`** in `test_from_config_env_token` — parallel test execution can cause data races

**Minor:**
- `VALID_EVENTS` is duplicated between `webhook.rs` and `config.rs::validate()`
- `build_placeholders` tests cover only 3 of 10 event types
- `env:VAR_NAME` startup-time resolution should be documented

## Test plan

- [ ] Review `docs/reviews/2026-04-01-pr-14.md` for accuracy
- [ ] Verify review comment was posted on PR #14
- [ ] Address blocking issues in PR #14 before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)