### PR TITLE
docs(plan): hermetic toolchain PATH exposure

### DIFF
--- a/docs/plans/2026-04-02-hermetic-toolchain-path.md
+++ b/docs/plans/2026-04-02-hermetic-toolchain-path.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Expose the hermetic `cargo`, `rustc`, `rustfmt`, and `clippy-driver` binaries on PATH inside drone sessions so that `cargo check`, `cargo test`, `rustfmt --check`, and `cargo clippy` work without a `buck2 run` prefix.
+**Goal:** Expose the hermetic `cargo`, `rustc`, `rustfmt`, and `clippy-driver` binaries on PATH so they're available after running `./tools/buckstrap.sh` — no system rustup needed.
 
-**Architecture:** Four independent changes: (1) new `tools:toolchain-bin` Buck2 genrule producing a self-relocatable wrapper directory, (2) `materialize_toolchain_bin()` helper in `environment.rs` that materialises the directory via Buck2 and returns the `bin/` path, (3) call site in `drone.rs` `setup()` that prepends the `bin/` path to `PATH` in `.drone-env`, (4) symlink step in `buckstrap.sh` for local dev.
+**Architecture:** Three independent changes: (1) visibility fix for `clippy-x86_64-linux` in `toolchains/BUCK`, (2) new `tools:toolchain-bin` Buck2 genrule producing a self-relocatable wrapper directory, (3) `buckstrap.sh` materialises the target and symlinks wrappers to `~/.local/bin/`, plus CLAUDE.md documentation.
 
 **Spec:** `docs/specs/2026-04-02-hermetic-toolchain-path-design.md`
 
@@ -18,14 +18,12 @@
 |------|--------|
 | `toolchains/BUCK` | Add `visibility = ["PUBLIC"]` to `clippy-x86_64-linux` target |
 | `tools/BUCK` | Add `toolchain-bin` genrule |
-| `src/drones/claude/base/src/environment.rs` | Add `materialize_toolchain_bin()` function |
-| `src/drones/claude/base/src/drone.rs` | Call `materialize_toolchain_bin()` in `setup()`, push PATH to env_vars |
 | `tools/buckstrap.sh` | Symlink wrappers to `~/.local/bin/` after warming cache |
-| `CLAUDE.md` | Document PATH guarantee for drone sessions in "Build System" section |
+| `CLAUDE.md` | Document hermetic toolchain availability in "Build System" section |
 
 ### No new files
 
-All changes are modifications to existing files.
+All changes are modifications to existing files. No drone code changes.
 
 ---
 
@@ -105,7 +103,7 @@ Add at the end of `tools/BUCK`:
 # -- hermetic toolchain wrappers -----------------------------------------------
 # Produces a self-relocatable bin/ directory with cargo, rustc, rustdoc, rustfmt,
 # and clippy-driver. Path resolved at runtime via readlink -f, not baked in.
-# Usage (drone setup): buck2 build root//tools:toolchain-bin --show-full-output
+# Usage: buck2 build root//tools:toolchain-bin --show-full-output
 
 genrule(
     name = "toolchain-bin",
@@ -199,201 +197,14 @@ git commit -m "feat(tools): add toolchain-bin genrule with self-relocatable wrap
 
 ---
 
-## Task 3: Add `materialize_toolchain_bin()` to `environment.rs`
-
-**Files:**
-- Modify: `src/drones/claude/base/src/environment.rs`
-
-This async function runs `buck2 build root//tools:toolchain-bin --show-full-output`
-inside the cloned workspace and parses the output path from stdout. It returns the
-path to the `bin/` subdirectory inside the materialised directory. Buck2 materialises
-the artifact on first call and returns the cached path on all subsequent calls
-(sub-second with warm cache).
-
-The function is intentionally **non-fatal at the call site** — if Buck2 is unavailable
-or the build fails, the drone session continues without the hermetic PATH.
-
-- [ ] **Step 1: Add `materialize_toolchain_bin` to `environment.rs`**
-
-In `src/drones/claude/base/src/environment.rs`, add after the `clone_repo` function
-(after line 209), before the `cleanup` function:
-
-```rust
-/// Materialise the hermetic toolchain wrapper directory via Buck2 and return
-/// the path to its `bin/` subdirectory.
-///
-/// Runs `buck2 build root//tools:toolchain-bin --show-full-output` inside
-/// `workspace`. Buck2 materialises the artifact on first call and returns the
-/// cached path on all subsequent calls (sub-second with a warm cache).
-///
-/// Returns `Err` if Buck2 is unavailable, the build fails, or the output line
-/// cannot be parsed. The caller should treat this as non-fatal.
-pub async fn materialize_toolchain_bin(workspace: &Path) -> Result<PathBuf> {
-    let output = Command::new("buck2")
-        .args([
-            "build",
-            "root//tools:toolchain-bin",
-            "--show-full-output",
-        ])
-        .current_dir(workspace)
-        .output()
-        .await
-        .context("failed to spawn `buck2 build root//tools:toolchain-bin`")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!(
-            "`buck2 build root//tools:toolchain-bin` failed (exit {:?}): {stderr}",
-            output.status.code()
-        );
-    }
-
-    // stdout line format: "root//tools:toolchain-bin <abs-path>"
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let abs_path = stdout
-        .lines()
-        .find_map(|line| {
-            let mut parts = line.split_whitespace();
-            let label = parts.next()?;
-            let path = parts.next()?;
-            if label == "root//tools:toolchain-bin" {
-                Some(path.to_string())
-            } else {
-                None
-            }
-        })
-        .context("could not find `root//tools:toolchain-bin` output path in buck2 stdout")?;
-
-    Ok(PathBuf::from(abs_path).join("bin"))
-}
-```
-
-- [ ] **Step 2: Verify the crate compiles**
-
-Run: `cd src/drones/claude/base && cargo check`
-Expected: compiles. (Failure on the embedded `claude-cli` binary is a pre-existing
-issue unrelated to this change.)
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add src/drones/claude/base/src/environment.rs
-git commit -m "feat(drone/env): add materialize_toolchain_bin() to expose hermetic tools on PATH"
-```
-
----
-
-## Task 4: Call `materialize_toolchain_bin` from `drone.rs` `setup()`
-
-**Files:**
-- Modify: `src/drones/claude/base/src/drone.rs`
-
-In `setup()`, after clone and task file setup, call `materialize_toolchain_bin`.
-On success, prepend its `bin/` path to `PATH` and push it into `env_vars`.
-On failure, log a warning and continue — the session may still succeed if the
-task doesn't exercise `cargo`/`rustc` directly.
-
-`env_vars` is written to `.drone-env` at the end of `setup()`, which
-`execute()` reads back and injects into the Claude CLI subprocess via the existing
-`extra_env` mechanism.
-
-**Current `setup()` structure (lines 19–67) for reference:**
-1. `create_home` (line 20)
-2. Configure GitHub auth from secrets (lines 23–27)
-3. `clone_repo` (lines 29–35)
-4. `write_task` (line 36)
-5. Generate stage-specific CLAUDE.md (lines 39–45)
-6. Configure MCP URL (lines 48–51)
-7. Collect `env_vars` (lines 53–64) — `BUCK2_RE_HTTP_HEADERS` from secrets
-8. Write `env_vars` if non-empty (lines 63–65)
-9. `return Ok(env)` (line 67)
-
-The new toolchain step is inserted into step 7 (env_vars collection), after the
-BuildBuddy key block. The `write_env_vars` guard must also be relaxed so PATH
-is written even when no BB key is present.
-
-- [ ] **Step 1: Insert toolchain materialisation into `setup()`**
-
-In `src/drones/claude/base/src/drone.rs`, replace the env_vars collection and
-write block (lines 53–65):
-
-```rust
-        // Collect environment variables for the drone session
-        let mut env_vars = Vec::new();
-        if let Some(secrets) = job.config.get("secrets") {
-            if let Some(bb_key) = secrets.get("buildbuddy_api_key").and_then(|v| v.as_str()) {
-                env_vars.push((
-                    "BUCK2_RE_HTTP_HEADERS".to_string(),
-                    format!("x-buildbuddy-api-key:{bb_key}"),
-                ));
-            }
-        }
-        if !env_vars.is_empty() {
-            environment::write_env_vars(&env.home, &env_vars).await?;
-        }
-```
-
-with:
-
-```rust
-        // Collect environment variables for the drone session
-        let mut env_vars = Vec::new();
-        if let Some(secrets) = job.config.get("secrets") {
-            if let Some(bb_key) = secrets.get("buildbuddy_api_key").and_then(|v| v.as_str()) {
-                env_vars.push((
-                    "BUCK2_RE_HTTP_HEADERS".to_string(),
-                    format!("x-buildbuddy-api-key:{bb_key}"),
-                ));
-            }
-        }
-
-        // Materialise hermetic toolchain and prepend its bin/ to PATH.
-        // Non-fatal: session continues if Buck2 or the build is unavailable.
-        match environment::materialize_toolchain_bin(&env.workspace).await {
-            Ok(bin_dir) => {
-                let existing_path =
-                    std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".into());
-                env_vars.push((
-                    "PATH".to_string(),
-                    format!("{}:{existing_path}", bin_dir.display()),
-                ));
-                tracing::info!(bin_dir = %bin_dir.display(), "hermetic toolchain on PATH");
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "failed to materialise hermetic toolchain; cargo/rustc may be unavailable"
-                );
-            }
-        }
-
-        if !env_vars.is_empty() {
-            environment::write_env_vars(&env.home, &env_vars).await?;
-        }
-```
-
-- [ ] **Step 2: Verify the crate compiles**
-
-Run: `cd src/drones/claude/base && cargo check`
-Expected: compiles.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add src/drones/claude/base/src/drone.rs
-git commit -m "feat(drone): prepend hermetic toolchain bin/ to PATH during setup"
-```
-
----
-
-## Task 5: Extend `buckstrap.sh` with toolchain symlinks
+## Task 3: Extend `buckstrap.sh` with toolchain symlinks
 
 **Files:**
 - Modify: `tools/buckstrap.sh`
 
 After the existing `buck2 build root//...` warm-up step, materialise `toolchain-bin`
-and symlink its wrappers into `~/.local/bin/`. This provides the same `cargo`/`rustc`
-experience for local developers without copying any binaries.
+and symlink its wrappers into `~/.local/bin/`. This provides `cargo`/`rustc`/`rustfmt`/
+`clippy-driver` on PATH for local developers without copying any binaries.
 
 Symlinks (not copies) preserve the single-source-of-truth: the Buck2 content-addressed
 cache. If the cache is cleaned, symlinks break, but `buckstrap.sh` repairs them on
@@ -434,74 +245,52 @@ git commit -m "feat(buckstrap): symlink hermetic toolchain wrappers to ~/.local/
 
 ---
 
-## Task 6: Update `CLAUDE.md` to document the PATH guarantee
+## Task 4: Update `CLAUDE.md` to document toolchain availability
 
 **Files:**
 - Modify: `CLAUDE.md`
 
-Add a callout to the "Build System" section documenting that `cargo`, `rustc`,
-`rustfmt`, and `clippy-driver` are automatically on PATH in drone environments.
-This informs drone agents (who read the project CLAUDE.md as part of their context)
-that they can use these tools directly.
+Add a note to the "Build System" section documenting that after running `buckstrap.sh`,
+`cargo`, `rustc`, `rustfmt`, and `clippy-driver` are available on PATH via hermetic
+toolchain wrappers in `~/.local/bin/`.
 
-Also add guidance to prefer `cargo check`/`cargo test` over `cargo build` (which
-would bypass Buck2's build graph) and to prefer `buck2 build ...[clippy.txt]` for
-CI-equivalent clippy runs.
+Also add guidance to prefer `cargo check`/`cargo test` over `cargo build` (which would
+bypass Buck2's build graph) and to prefer `buck2 build ...[clippy.txt]` for CI-equivalent
+clippy runs.
 
-- [ ] **Step 1: Add drone-environment note to the "Build System" section**
+- [ ] **Step 1: Add toolchain note to the "Build System" section**
 
 In `CLAUDE.md`, find the "Build System" section header. After the opening paragraph
 (after the `buck2 build root//...` / `buck2 run root//...` bullet list and before the
 "### Remote Execution (BuildBuddy)" subsection), insert:
 
 ```markdown
-**In drone environments**, `cargo`, `rustc`, `rustfmt`, and `clippy-driver` are
-placed on `PATH` automatically during drone setup (via `buck2 build root//tools:toolchain-bin`).
-Use them directly — no `buck2 run` prefix needed.
+**Hermetic dev tools:** After running `./tools/buckstrap.sh`, `cargo`, `rustc`, `rustdoc`,
+`rustfmt`, and `clippy-driver` are available on PATH via hermetic wrappers symlinked to
+`~/.local/bin/`. These use the exact same toolchain as Buck2 builds — no system rustup needed.
 
-- `cargo check` / `cargo test` — fast feedback loop (no `buck2 run` prefix needed)
-- `cargo build` — avoid in drone sessions; use `buck2 build` instead to keep Buck2's
-  build graph consistent and leverage the shared remote cache
-- `cargo clippy` — acceptable for quick interactive checks; use
+- `cargo check` / `cargo test` — fast feedback loop, use freely
+- `cargo build` — avoid; use `buck2 build` instead to keep the build graph consistent
+  and leverage the shared remote cache
+- `cargo clippy` — acceptable for quick checks; use
   `buck2 build 'root//src/<crate>:<crate>[clippy.txt]'` for CI-equivalent results
 - `rustfmt --check` / `rustfmt` — use directly (same binary as `buck2 run root//tools:rustfmt`)
 ```
 
-- [ ] **Step 2: Verify the CLAUDE.md is valid Markdown**
-
-Run: `grep -n "In drone environments" CLAUDE.md`
-Expected: prints the line you just added.
-
-- [ ] **Step 3: Commit**
+- [ ] **Step 2: Commit**
 
 ```bash
 git add CLAUDE.md
-git commit -m "docs: document hermetic toolchain PATH guarantee for drone environments"
+git commit -m "docs: document hermetic toolchain on PATH after buckstrap"
 ```
 
 ---
 
-## Task 7: Full verification
+## Task 5: Full verification
 
 **Files:** None (verification only)
 
-- [ ] **Step 1: Cargo check all affected crates**
-
-Run: `cargo check -p drone-sdk`
-Expected: compiles.
-
-Note: `claude-drone` requires an embedded `claude-cli` binary fetched by Buck2.
-If `cargo check` on that crate fails with a missing file error, that is a
-pre-existing issue. Verify the change compiles by inspecting the modified functions
-for type errors manually.
-
-- [ ] **Step 2: Run tests on affected crates**
-
-Run: `cd src/drones/claude/base && cargo test --lib`
-Expected: all existing tests pass (the new function has no tests yet — it invokes
-a real `buck2` binary, which is an integration concern).
-
-- [ ] **Step 3: Buck2 build and test the `toolchain-bin` target**
+- [ ] **Step 1: Buck2 build and test the `toolchain-bin` target**
 
 ```bash
 buck2 build root//tools:toolchain-bin
@@ -513,7 +302,7 @@ TOOLCHAIN_BIN=$(buck2 build root//tools:toolchain-bin --show-full-output 2>/dev/
 
 Expected: all print version strings.
 
-- [ ] **Step 4: Verify wrappers are self-relocatable**
+- [ ] **Step 2: Verify wrappers are self-relocatable**
 
 ```bash
 # Copy to a temp location and test there — simulates a moved Buck2 cache path
@@ -526,7 +315,12 @@ rm -rf "$TEMP_DIR"
 
 Expected: both print version strings (self-relocation works).
 
-- [ ] **Step 5: Run pre-commit hooks**
+- [ ] **Step 3: Verify buckstrap.sh syntax**
+
+Run: `bash -n tools/buckstrap.sh`
+Expected: exits 0 (no syntax errors)
+
+- [ ] **Step 4: Run pre-commit hooks**
 
 Run: `buck2 run root//tools:prek -- run --all-files`
 Expected: all hooks pass.
@@ -535,18 +329,15 @@ Expected: all hooks pass.
 
 ## Open questions (not blocking, track separately)
 
-1. **Persistent `CARGO_HOME` across drone sessions** — with `HOME=/tmp/drone-{id}`,
-   Cargo writes its registry to `/tmp/drone-{id}/.cargo`, which is deleted by
-   `teardown()`. Consider pointing `CARGO_HOME` at a shared directory (e.g.
-   `/var/cache/kerrigan/cargo`) to avoid re-downloading crates on every session.
-   Tracked separately from this issue.
-
-2. **`cargo clippy` vs `buck2 build ...[clippy.txt]`** — verify that `cargo clippy`
+1. **`cargo clippy` vs `buck2 build ...[clippy.txt]`** — verify that `cargo clippy`
    (which drives `clippy-driver` via Cargo metadata) produces equivalent diagnostics
-   to `buck2 build ...[clippy.txt]`. Document the preferred invocation in
-   `src/drones/claude/base/src/config/CLAUDE.md` and the stage-specific CLAUDE.md
-   templates in `src/drones/claude/base/src/stages.rs`.
+   to `buck2 build ...[clippy.txt]`. Document the preferred invocation.
 
-3. **macOS local dev** — `readlink -f` is not available on macOS (BSD `readlink` lacks
-   `-f`). The wrappers work on Linux (drone target). If macOS dev support is added,
-   `buckstrap.sh` will need a `greadlink` fallback (via coreutils).
+2. **macOS local dev** — `readlink -f` is not available on macOS (BSD `readlink` lacks
+   `-f`). The wrappers work on Linux. If macOS dev support is added, `buckstrap.sh`
+   will need a `greadlink` fallback (via coreutils).
+
+3. **Drone integration** — once this project-level tooling is in place, drones can
+   consume it by running `buckstrap.sh` during setup or by calling
+   `buck2 build root//tools:toolchain-bin --show-full-output` and prepending the
+   result to PATH. That's a separate change to drone code.

--- a/docs/specs/2026-04-02-hermetic-toolchain-path-design.md
+++ b/docs/specs/2026-04-02-hermetic-toolchain-path-design.md
@@ -1,4 +1,4 @@
-# Hermetic Toolchain Binaries on PATH in Remote Environments
+# Hermetic Toolchain Binaries on PATH — Project Setup
 
 **Date:** 2026-04-02
 **Status:** Draft
@@ -8,15 +8,14 @@
 
 ## Problem Statement
 
-Kerrigan drones (Claude Code agents) run in isolated environments with no system Rust
-installed. The hermetic Rust toolchain — rustc, cargo, clippy-driver, and rustfmt — is
-only reachable through Buck2 sub-targets (e.g. `buck2 run root//tools:rustfmt`). When a
-drone agent runs `cargo check`, `cargo test`, `rustfmt --check`, or `cargo clippy`,
-those commands fail with "command not found".
+The hermetic Rust toolchain (rustc, cargo, clippy-driver, rustfmt) is fetched by Buck2
+into `buck-out/` but its binaries aren't exposed on PATH. Developers and any environment
+running in this repo can only reach these tools via `buck2 run` wrappers or by having a
+separate system rustup installation.
 
-This makes interactive development in drone sessions painful: the CLAUDE.md explicitly
-advertises `cargo check` / `cargo test` as the fast-feedback loop, but that loop is
-broken in every drone-spawned environment.
+This is a project setup problem: after `./tools/buckstrap.sh`, the developer should have
+`cargo`, `rustc`, `rustfmt`, and `clippy-driver` available without needing rustup or any
+system Rust installation. The same applies to containers built from the Dockerfile.
 
 ---
 
@@ -24,39 +23,25 @@ broken in every drone-spawned environment.
 
 **Q: Which binaries are needed?**
 
-`cargo`, `rustc`, `rustfmt`, and `clippy-driver`. The rustc distribution archive
-(`rustc-nightly-x86_64-unknown-linux-gnu.tar.xz`) bundles cargo alongside rustc and
-rustdoc. Clippy is downloaded separately and already gets a self-relocatable wrapper in
-`toolchains/rust_dist.bzl`. rustfmt has a wrapper genrule in `tools/BUCK` that sets
-`LD_LIBRARY_PATH`, but it is only accessible via `buck2 run root//tools:rustfmt`.
+`cargo`, `rustc`, `rustdoc`, `rustfmt`, and `clippy-driver`. The rustc distribution
+archive bundles cargo alongside rustc and rustdoc. Clippy and rustfmt are downloaded as
+separate archives. Currently cargo is not fetched at all — Buck2 drives rustc directly
+and doesn't need it.
 
-**Q: Is `buck2` available inside a drone session?**
+**Q: What archives does the toolchain already fetch?**
 
-Yes. `buckstrap.sh` installs it to `/usr/local/bin/buck2`, the Dockerfile copies it into
-the container image, and `drone.rs` inherits the Queen's PATH (which includes
-`/usr/local/bin`). The `.drone-env` mechanism also lets the drone set additional
-environment variables that are forwarded to the Claude CLI subprocess.
-
-**Q: Does the drone run `buckstrap.sh` inside the cloned repo?**
-
-No. The current setup phase (`environment.rs`) only clones the repo and writes config
-files. It does not run any build commands. The Claude CLI session then runs inside
-`env.workspace` (the cloned repo root) with the full inherited PATH.
+- `rustc-x86_64-linux` — rustc, cargo, rustdoc, stdlib
+- `rust-std-x86_64-linux` — standard library (used by Buck2 toolchain)
+- `clippy-x86_64-linux` — clippy-driver binary
+- `rustfmt-x86_64-linux` — rustfmt binary
+- Corresponding aarch64 variants for cross-compilation
 
 **Q: Can Buck2 output paths be used in wrapper scripts portably?**
 
 The existing `tools:rustfmt` genrule (tagged `uses_local_filesystem_abspaths`) bakes
 absolute Buck2 cache paths into the wrapper script. That works only on the machine where
-the build ran and only as long as the cache artifact is present. A cross-machine or
-cross-session wrapper must find its sibling files relative to its own location at
-runtime.
-
-**Q: What are the Raspberry Pi resource constraints?**
-
-The target hardware is an RPi with AI HAT 2. Bundling the full rustc distribution
-(~150 MB uncompressed) into the drone binary would be prohibitive. The solution must
-avoid copying large toolchain artifacts at every drone setup; it should materialise them
-once via Buck2 and reuse the cached output.
+the build ran and only as long as the cache artifact is present. A portable wrapper must
+find its sibling files relative to its own location at runtime.
 
 ---
 
@@ -71,251 +56,92 @@ toolchain-bin/
   bin/
     cargo          ← self-relocatable wrapper script
     rustc          ← self-relocatable wrapper script
+    rustdoc        ← self-relocatable wrapper script
     rustfmt        ← self-relocatable wrapper script
-    clippy-driver  ← self-relocatable wrapper script (variant of existing sysroot wrapper)
-  rustc-dist/      ← copy/symlink of rustc http_archive output
-  rustfmt-dist/    ← copy/symlink of rustfmt http_archive output
+    clippy-driver  ← self-relocatable wrapper script
+  rustc-dist/      ← copy of rustc http_archive output
+  rustfmt-dist/    ← copy of rustfmt http_archive output
 ```
 
-Each wrapper resolves its own location:
+Each wrapper resolves its own location at runtime:
 
 ```bash
 #!/usr/bin/env bash
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
-export LD_LIBRARY_PATH="$SCRIPT_DIR/rustc-dist/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-exec "$SCRIPT_DIR/rustc-dist/bin/cargo" "$@"
+TOOLCHAIN_ROOT="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
+export LD_LIBRARY_PATH="$TOOLCHAIN_ROOT/rustc-dist/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$TOOLCHAIN_ROOT/rustc-dist/bin/cargo" "$@"
 ```
 
-In the drone setup phase, after clone, add one step:
-
-```rust
-// setup() in drone.rs
-let bin_dir = materialize_toolchain_bin(&env.workspace).await?;
-env_vars.push(("PATH".into(), format!("{}:{}", bin_dir, std::env::var("PATH").unwrap_or_default())));
-```
-
-`materialize_toolchain_bin` runs:
-```
-buck2 build root//tools:toolchain-bin --show-full-output 2>/dev/null
-```
-and parses the output path. Buck2 materialises the artifact on first call and returns the
-cached path on all subsequent calls (sub-second with warm cache).
+`buckstrap.sh` materialises this target and symlinks the wrappers into `~/.local/bin/`.
 
 **Pros:**
 - Fully hermetic: exact same toolchain version as Buck2 builds.
-- Self-relocatable: works on any machine where the Buck2 cache is populated.
-- Fast after first build: subsequent calls return the cached path immediately.
-- No changes to drone binary size.
-- Reuses the existing `uses_local_filesystem_abspaths`-free pattern established by the
-  sysroot clippy-driver wrapper.
+- Self-relocatable: works anywhere the Buck2 cache is populated.
+- Fast after first build: subsequent calls return cached path immediately.
+- No system rustup/rustc dependency.
 
 **Cons:**
-- Adds a `buck2 build` call to the drone setup critical path (~2–5 s cold, <1 s warm).
-- The drone setup Rust code gains a dependency on Buck2 being on PATH.
-- Absolute paths embedded in wrapper scripts are avoided, but Buck2 must be present to
-  materialise the directory initially.
+- First materialisation takes ~2–5 s (cold Buck2 cache).
+- Symlinks break if `buck2 clean` is run; repaired by re-running `buckstrap.sh`.
 
 ---
 
 ### Approach B — `buck2 run` Proxy Scripts
 
-Install thin shell scripts to `$HOME/.local/bin/` during drone setup:
+Install thin shell scripts that delegate to `buck2 run`:
 
 ```bash
 #!/usr/bin/env bash
 exec buck2 run root//tools:cargo -- "$@"
 ```
 
-No new genrule required. `tools:cargo` would be a new `genrule` that wraps the hermetic
-binary identically to `tools:rustfmt`.
-
-**Pros:**
-- Trivial to implement — just write a few files.
-- No wrapper-path concerns: Buck2 resolves everything at invocation time.
-- Adding a new tool is one line of shell.
+**Pros:** Trivial to implement.
 
 **Cons:**
-- Every `cargo check` or `cargo test` invocation spawns a full Buck2 process (~100–300 ms
-  cold-start overhead, repeatable per invocation).
-- Buck2 stdout/stderr bleed into tool output unless carefully redirected.
-- `cargo test` and interactive tools that re-exec themselves (`cargo clippy`, `cargo fmt`)
-  would each pay the Buck2 overhead — bad for test suites with many crates.
-- The proxy pattern is fragile if Buck2 is not on PATH inside the tool subprocess.
-
----
-
-### Approach C — Bundled Toolchain Tarball in Drone Binary
-
-At drone compile time, a genrule assembles a minimal toolchain tarball (cargo, rustc,
-rustfmt, clippy-driver, and the required `.so` files). The tarball is embedded in the
-drone binary via `include_bytes!`. During `setup()`, the drone extracts it to
-`$HOME/.local/bin/`.
-
-**Pros:**
-- Fully self-contained: zero runtime dependency on Buck2 or network.
-- Drone setup is deterministic and offline-capable.
-- No Buck2 invocation in the hot path.
-
-**Cons:**
-- Rustc distribution is ~150 MB uncompressed; even stripped and compressed, the drone
-  binary would grow by tens of megabytes — problematic for RPi storage and memory.
-- Every toolchain bump requires a full rebuild of the drone binary (already true, but the
-  artifact size makes iteration slower).
-- Duplication: the toolchain already lives in Buck2's content-addressed cache; embedding
-  it a second time wastes disk.
-- Cross-compilation (aarch64) would require embedding a second architecture's binaries
-  or a build-time platform select.
+- Every invocation spawns a full Buck2 process (~100–300 ms overhead).
+- Buck2 stdout/stderr bleed into tool output.
+- Tools that re-exec themselves (like `cargo clippy`) pay the overhead multiple times.
 
 ---
 
 ## Recommended Design (Approach A)
 
-### 1. New Buck2 genrule: `tools:toolchain-bin`
+### 1. Visibility fix: `clippy-x86_64-linux`
 
-Add to `tools/BUCK`:
+The `clippy-x86_64-linux` http_archive in `toolchains/BUCK` has no `visibility` annotation.
+Add `visibility = ["PUBLIC"]` so it can be referenced from `tools/BUCK`.
 
-```python
-genrule(
-    name = "toolchain-bin",
-    srcs = [
-        "toolchains//:rustc-x86_64-linux",
-        "toolchains//:rustfmt-x86_64-linux",
-        "toolchains//:clippy-x86_64-linux",
-    ],
-    out = "toolchain-bin",
-    type = "directory",
-    bash = """
-        set -euo pipefail
-        RUSTC_DIST="$PWD/$(location toolchains//:rustc-x86_64-linux)"
-        RUSTFMT_DIST="$PWD/$(location toolchains//:rustfmt-x86_64-linux)"
-        CLIPPY_DIST="$PWD/$(location toolchains//:clippy-x86_64-linux)"
-        OUT="$OUT"
+### 2. New Buck2 genrule: `tools:toolchain-bin`
 
-        mkdir -p "$OUT/rustc-dist" "$OUT/rustfmt-dist" "$OUT/bin"
+Add to `tools/BUCK`. The genrule copies the rustc, rustfmt, and clippy archives into a
+self-contained output directory, then generates self-relocatable wrapper scripts in `bin/`.
 
-        # Copy relevant subtrees (dereference symlinks so output is self-contained)
-        cp -rfL "$RUSTC_DIST"/. "$OUT/rustc-dist/"
-        cp -rfL "$RUSTFMT_DIST"/. "$OUT/rustfmt-dist/"
-        # clippy-driver binary only (the sysroot is already in rustc-dist)
-        cp -L "$CLIPPY_DIST/bin/clippy-driver" "$OUT/bin/clippy-driver-bin"
+Each wrapper uses `readlink -f "$0"` at runtime to find its own location and resolves
+`TOOLCHAIN_ROOT` relative to that — no absolute paths baked in at build time.
 
-        # Self-relocatable wrapper: all wrappers resolve TOOLCHAIN_ROOT relative to $0
-        write_wrapper() {
-            local name="$1" exec_path="$2"
-            cat > "$OUT/bin/$name" <<WRAPPER
-#!/usr/bin/env bash
-TOOLCHAIN_ROOT="\$(cd "\$(dirname "\$(readlink -f "\$0")")/.." && pwd)"
-export LD_LIBRARY_PATH="\$TOOLCHAIN_ROOT/rustc-dist/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
-exec "\$TOOLCHAIN_ROOT/$exec_path" "\$@"
-WRAPPER
-            chmod +x "$OUT/bin/$name"
-        }
+### 3. `buckstrap.sh` integration
 
-        write_wrapper cargo    "rustc-dist/bin/cargo"
-        write_wrapper rustc    "rustc-dist/bin/rustc"
-        write_wrapper rustdoc  "rustc-dist/bin/rustdoc"
-        write_wrapper rustfmt  "rustfmt-dist/bin/rustfmt"
-
-        # clippy-driver needs the same LD_LIBRARY_PATH treatment
-        cat > "$OUT/bin/clippy-driver" <<WRAPPER
-#!/usr/bin/env bash
-TOOLCHAIN_ROOT="\$(cd "\$(dirname "\$(readlink -f "\$0")")/.." && pwd)"
-export LD_LIBRARY_PATH="\$TOOLCHAIN_ROOT/rustc-dist/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
-exec "\$TOOLCHAIN_ROOT/bin/clippy-driver-bin" "\$@"
-WRAPPER
-        chmod +x "$OUT/bin/clippy-driver"
-    """,
-    visibility = ["PUBLIC"],
-)
-```
-
-The key insight: each wrapper script uses `readlink -f "$0"` at **runtime** to find its
-own location and resolves `TOOLCHAIN_ROOT` relative to that. This is identical to the
-approach already used for the clippy-driver wrapper inside `rust_dist.bzl` (lines 36–37).
-No absolute paths are baked in at build time.
-
-### 2. Drone setup integration (`src/drones/claude/base/`)
-
-Add a new function `environment::materialize_toolchain_bin(workspace: &Path) -> Result<PathBuf>`:
-
-```rust
-/// Run `buck2 build root//tools:toolchain-bin --show-full-output` inside the cloned
-/// workspace and return the path to the materialised `toolchain-bin/bin` directory.
-pub async fn materialize_toolchain_bin(workspace: &Path) -> Result<PathBuf> {
-    let output = Command::new("buck2")
-        .args([
-            "build",
-            "root//tools:toolchain-bin",
-            "--show-full-output",
-        ])
-        .current_dir(workspace)
-        .output()
-        .await
-        .context("failed to run buck2 build for toolchain-bin")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("buck2 build root//tools:toolchain-bin failed: {stderr}");
-    }
-
-    // Output format: "root//tools:toolchain-bin <abs-path>\n"
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let abs_path = stdout
-        .lines()
-        .find_map(|line| line.split_whitespace().nth(1))
-        .context("no output path in buck2 --show-full-output")?;
-
-    Ok(PathBuf::from(abs_path).join("bin"))
-}
-```
-
-In `drone.rs` `setup()`, after `write_task` and before returning `env`:
-
-```rust
-// Materialise hermetic toolchain and prepend its bin/ dir to PATH.
-match environment::materialize_toolchain_bin(&env.workspace).await {
-    Ok(bin_dir) => {
-        let existing_path = std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".into());
-        env_vars.push(("PATH".into(), format!("{}:{existing_path}", bin_dir.display())));
-        tracing::info!(bin_dir = %bin_dir.display(), "hermetic toolchain on PATH");
-    }
-    Err(e) => {
-        // Non-fatal: the drone session may still succeed if the task doesn't need cargo.
-        tracing::warn!(error = %e, "failed to materialise hermetic toolchain; cargo/rustc may be unavailable");
-    }
-}
-```
-
-`PATH` is then written to `.drone-env` alongside `BUCK2_RE_HTTP_HEADERS` and forwarded
-to the Claude CLI subprocess via the existing `extra_env` mechanism.
-
-### 3. `buckstrap.sh` integration (local dev)
-
-Extend `tools/buckstrap.sh` to install the same wrappers into the developer's
-`~/.local/bin/` after warming the cache:
+After the existing cache warm-up step, materialise `toolchain-bin` and symlink its
+wrappers into `~/.local/bin/`:
 
 ```bash
-echo "Installing hermetic toolchain wrappers to ~/.local/bin/..."
 TOOLCHAIN_BIN=$(buck2 build root//tools:toolchain-bin --show-full-output 2>/dev/null \
   | awk 'NR==1{print $2}')
-mkdir -p "$HOME/.local/bin"
-for bin in cargo rustc rustdoc rustfmt clippy-driver; do
-    ln -sf "$TOOLCHAIN_BIN/bin/$bin" "$HOME/.local/bin/$bin"
-done
-echo "  -> add ~/.local/bin to PATH if not already present"
+if [[ -n "$TOOLCHAIN_BIN" ]]; then
+    mkdir -p "$HOME/.local/bin"
+    for bin in cargo rustc rustdoc rustfmt clippy-driver; do
+        ln -sf "$TOOLCHAIN_BIN/bin/$bin" "$HOME/.local/bin/$bin"
+    done
+fi
 ```
 
-This is symlinks, not copies, so there is no duplication — the Buck2 cache remains the
-single source of truth. Symlinks break if the cache is cleaned but are trivially repaired
-by re-running `buckstrap.sh` (which warms the cache anyway).
+Symlinks, not copies — Buck2 cache remains the single source of truth.
 
-### 4. CLAUDE.md update (workspace)
+### 4. CLAUDE.md update
 
-Update the "Build System" section of `workspace/CLAUDE.md` to document the guaranteed
-availability of these tools:
-
-> **In drone environments**, `cargo`, `rustc`, `rustfmt`, and `clippy-driver` are placed
-> on PATH automatically during setup. Use them directly; no `buck2 run` prefix needed.
+Document the toolchain availability in the "Build System" section. After running
+`buckstrap.sh`, `cargo`, `rustc`, `rustfmt`, and `clippy-driver` are on PATH via
+`~/.local/bin/`. No system rustup needed.
 
 ---
 
@@ -323,13 +149,13 @@ availability of these tools:
 
 | File | Change |
 |------|--------|
+| `toolchains/BUCK` | Add `visibility = ["PUBLIC"]` to `clippy-x86_64-linux` |
 | `tools/BUCK` | Add `toolchain-bin` genrule |
-| `src/drones/claude/base/src/environment.rs` | Add `materialize_toolchain_bin()` |
-| `src/drones/claude/base/src/drone.rs` | Call it in `setup()`, push `PATH` to env_vars |
 | `tools/buckstrap.sh` | Symlink wrappers to `~/.local/bin/` |
-| `workspace/CLAUDE.md` | Document PATH guarantee for drone sessions |
+| `CLAUDE.md` | Document hermetic toolchain on PATH |
 
-No changes to `toolchains/`, `prelude/`, Overseer, Queen, or any other component.
+No changes to drone code, Overseer, Queen, or any Rust source files. This is purely
+project setup infrastructure.
 
 ---
 
@@ -337,31 +163,19 @@ No changes to `toolchains/`, `prelude/`, Overseer, Queen, or any other component
 
 | Failure | Mitigation |
 |---------|-----------|
-| `buck2 build` fails in setup (network, missing fixup) | Non-fatal warning; session continues without hermetic PATH. Drone CLAUDE.md should note `cargo` may be unavailable. |
-| Buck2 cache evicted mid-session | Wrapper scripts resolve paths at invocation time; if `$TOOLCHAIN_ROOT/rustc-dist/bin/cargo` is gone, the error is clear ("No such file"). Re-running `buck2 build root//tools:toolchain-bin` would restore it. |
-| PATH ordering conflict with system rustc | Hermetic path is prepended, taking precedence over any system Rust. This is intentional. |
-| aarch64 drone (RPi target) | The genrule as written targets `x86_64-unknown-linux-gnu`. Cross-compilation is out of scope for this issue; drone binaries run on x86_64 hosts, cross-compile targets are built by Buck2 at build time, not at drone runtime. |
-| `readlink -f` unavailable (macOS `readlink` lacks `-f`) | Drones run on Linux only. `buckstrap.sh` symlinks for local dev would need a macOS variant if macOS dev is added. Filed as a follow-on concern. |
+| `buck2 build` fails (network, missing fixup) | `buckstrap.sh` prints warning, skips symlink step. Developer falls back to system rustup. |
+| Buck2 cache evicted (`buck2 clean`) | Symlinks break. Re-run `buckstrap.sh` to repair. |
+| PATH ordering conflict with system rustc | `~/.local/bin` position in PATH depends on user's shell config. Document that hermetic toolchain should take precedence. |
+| `readlink -f` unavailable (macOS) | Drones and CI run Linux. For macOS local dev, `buckstrap.sh` would need a `greadlink` fallback — file as follow-on if needed. |
 
 ---
 
 ## Open Questions
 
-1. **Cargo `.cargo/` home:** `cargo` writes its registry and build cache to
-   `$CARGO_HOME` (default `~/.cargo`). With `HOME=/tmp/drone-{id}`, this is
-   `/tmp/drone-{id}/.cargo`, which is cleaned up by `teardown()`. Should we configure
-   `CARGO_HOME` to point to a persistent cache directory on the host to avoid
-   re-downloading crates on every drone session? (Out of scope for this issue, but worth
-   tracking.)
+1. **`cargo build` vs `buck2 build` divergence:** Making `cargo` directly accessible may
+   encourage use of `cargo build` instead of `buck2 build`. The two produce separate build
+   artifacts and don't share a cache. CLAUDE.md should document that `cargo check`/`cargo test`
+   are the intended use — `cargo build` should go through `buck2 build`.
 
-2. **`cargo build` vs `buck2 build` divergence:** Making `cargo` directly accessible may
-   encourage drones to use `cargo build` instead of `buck2 build`. The two produce
-   separate build artifacts and don't share a cache. Consider whether the CLAUDE.md
-   should explicitly restrict cargo to `cargo check`/`cargo test` and direct `cargo build`
-   to `buck2 build`.
-
-3. **Clippy via `cargo clippy` vs `buck2 build ...[clippy.txt]`:** `cargo clippy`
-   invokes `clippy-driver` directly on Cargo metadata; `buck2 build ...[clippy.txt]`
-   uses the hermetic toolchain via Buck2's build graph. Both should produce equivalent
-   diagnostics now that clippy-driver is the same binary. Verify this assumption and
-   document the preferred invocation in the drone CLAUDE.md.
+2. **Clippy via `cargo clippy` vs `buck2 build ...[clippy.txt]`:** Both should produce
+   equivalent diagnostics since they use the same clippy-driver binary. Worth verifying.


### PR DESCRIPTION
## Summary

- Adds spec and implementation plan for exposing hermetic `cargo`, `rustc`, `rustfmt`, and `clippy-driver` on PATH as project-level tooling (issue #18)
- Plan follows Approach A from the spec: `tools:toolchain-bin` genrule + `buckstrap.sh` symlinks to `~/.local/bin/`
- Structured as 5 tasks with checkbox steps, ready for implementation
- **No drone code changes** — drone integration is a separate follow-on

## Plan location

`docs/plans/2026-04-02-hermetic-toolchain-path.md`

## Spec

`docs/specs/2026-04-02-hermetic-toolchain-path-design.md`

## Test plan

- [x] Reviewer verifies plan tasks cover all files listed in the spec's "Scope & Files Changed" table
- [x] Reviewer confirms the `clippy-x86_64-linux` visibility fix is included
- [x] Reviewer confirms the HEREDOC quoting strategy for self-relocatable wrappers matches the spec's intent
- [x] Reviewer confirms open questions are captured for follow-on tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)