### PR TITLE
feat(queen): per-drone-type concurrency limits

### DIFF
--- a/docs/abathur/queen.md
+++ b/docs/abathur/queen.md
@@ -6,13 +6,13 @@ lastmod: 2026-04-06
 tags: [queen, hatchery, actors, drones, notifications]
 sources:
   - path: src/queen/src/main.rs
-    hash: fe0adecce258ca4dd3090d6dec4c7ef85fc7bd81c8b9efb8c6561d49eea035d5
+    hash: bc1bc079bbf5d652a69129f1e55014f1e26399a6c38097598ac1125e46d5ae64
   - path: src/queen/src/config.rs
-    hash: 0817c30a5d093a59f544dea8a078569aea705fd1280496cd93268a092590e6f4
+    hash: eb01cb6f0031220ac34800260175409f7270d70e585f4ca723f9c0d5e8b730e3
   - path: src/queen/src/messages.rs
     hash: 134afb9ab6df2f36fc00be9adb76f9ee5e03657045062458085cbdafaf7c0c4f
   - path: src/queen/src/actors/supervisor.rs
-    hash: a249166e0286de5e9e95bba642d71005988a39349e644f2114af7d9cf5344215
+    hash: 0885e9ea6888d9eef1e5a0124b1de5a07009042c7f53ade64954e363a5cb8b65
   - path: src/queen/src/actors/poller.rs
     hash: 7317cc684b88dd4cc9c23a4cc1858b0fc3735c415880cdb10efd52d3b610d0e8
   - path: src/queen/src/actors/heartbeat.rs

--- a/docs/abathur/queen.md
+++ b/docs/abathur/queen.md
@@ -8,11 +8,11 @@ sources:
   - path: src/queen/src/main.rs
     hash: bc1bc079bbf5d652a69129f1e55014f1e26399a6c38097598ac1125e46d5ae64
   - path: src/queen/src/config.rs
-    hash: eb01cb6f0031220ac34800260175409f7270d70e585f4ca723f9c0d5e8b730e3
+    hash: 4bec470372566db28ad14f722aba506054e15448f74c8bb7c4eb9ddb261398eb
   - path: src/queen/src/messages.rs
     hash: 134afb9ab6df2f36fc00be9adb76f9ee5e03657045062458085cbdafaf7c0c4f
   - path: src/queen/src/actors/supervisor.rs
-    hash: 0885e9ea6888d9eef1e5a0124b1de5a07009042c7f53ade64954e363a5cb8b65
+    hash: 82403576acaab8e101ab13ece68923f3b54edc3313ddc7bc249d29c424d488ac
   - path: src/queen/src/actors/poller.rs
     hash: 7317cc684b88dd4cc9c23a4cc1858b0fc3735c415880cdb10efd52d3b610d0e8
   - path: src/queen/src/actors/heartbeat.rs
@@ -65,20 +65,24 @@ On validation failure, immediately fails the run in Overseer.
 
 Maintains `active: HashMap<String, DroneHandle>` and `queue: VecDeque<SpawnRequest>`.
 
+**Concurrency control:** Two-level gating via `can_spawn()`. Global `max_concurrency` is checked first, then per-drone-type limits from `queen.drones.<type>.max_concurrency`. Per-type limits cannot exceed the global limit at runtime (validation warns on misconfiguration). Timeout and stall threshold are resolved per-type via `EffectiveDroneConfig::resolve()`, falling back to global defaults.
+
 **Select loop:**
-- Spawn request → if under `max_concurrency`, spawn drone; else queue
+- Spawn request → if under concurrency limits (global + per-type), spawn drone; else queue
 - Status query → reply with active/queued counts (for heartbeat)
-- Health tick (5s) → drain protocol messages, check drone health, dequeue
+- Health tick (5s) → drain protocol messages, check drone health, dequeue (indexed iteration skips type-blocked items to avoid head-of-line blocking)
 
 **DroneHandle:**
 ```rust
 struct DroneHandle {
     job_run_id: String,
+    drone_type: String,       // binary name, used for per-type concurrency counting
     process: Child,           // OS process
     started_at: Instant,
-    timeout: Duration,
+    timeout: Duration,        // resolved per-type or global
     last_activity: Instant,   // updated on protocol msg or stderr
     stall_notified: bool,
+    stall_threshold: Duration, // resolved per-type or global
     protocol_rx: mpsc::Receiver<DroneMessage>,
     stderr_rx: mpsc::Receiver<()>,
     stdin_tx: Option<mpsc::Sender<QueenMessage>>,
@@ -169,6 +173,9 @@ Disabled by default. When enabled, monitors completed runs and triggers heuristi
 | `queen.stall_threshold` | Stall detection (s) | 300 |
 | `queen.drone_dir` | Drone binary directory | "./drones" |
 | `queen.default_repo_url` | Fallback repo URL | None |
+| `queen.drones.<type>.max_concurrency` | Per-type concurrency limit | None (global only) |
+| `queen.drones.<type>.drone_timeout` | Per-type timeout | inherits `queen.drone_timeout` |
+| `queen.drones.<type>.stall_threshold` | Per-type stall detection (s) | inherits `queen.stall_threshold` |
 | `creep.enabled` | Enable Creep sidecar | true |
 | `creep.binary` | Creep binary path | "./creep" |
 | `creep.health_port` | Creep health check port | 9090 |
@@ -180,6 +187,20 @@ Disabled by default. When enabled, monitors completed runs and triggers heuristi
 | `notifications.backend` | "log" or "webhook" | "log" |
 | `evolution.enabled` | Enable evolution actor | false |
 | `evolution.run_interval` | Runs between analyses | 10 |
+
+**Per-drone-type config:** The `[queen.drones.<type>]` sections allow overriding concurrency, timeout, and stall threshold per drone binary name. All fields are optional — omitted values inherit from the corresponding global `queen.*` setting. Resolution is handled by `EffectiveDroneConfig::resolve()`, used by both config tests and the supervisor at runtime (single code path). Validation rejects invalid values (zero/negative concurrency, unparseable timeouts, zero stall) and warns when a per-type `max_concurrency` exceeds the global limit.
+
+```toml
+[queen.drones.claude-drone]
+max_concurrency = 2       # at most 2 claude-drone instances
+drone_timeout = "2h"
+stall_threshold = 300
+
+[queen.drones.native-drone]
+max_concurrency = 4
+drone_timeout = "30m"     # native drones are faster
+stall_threshold = 120
+```
 
 CLI flags (`--name`, `--overseer-url`, `--max-concurrency`, `--drone-dir`) and env vars (`QUEEN_NAME`, etc.) override config.
 

--- a/hatchery.toml
+++ b/hatchery.toml
@@ -6,6 +6,16 @@ max_concurrency = 4
 drone_timeout = "2h"
 default_repo_url = "https://github.com/rsJames-ttrpg/kerrigan.git"
 
+[queen.drones.claude-drone]
+max_concurrency = 2
+drone_timeout = "2h"
+stall_threshold = 300
+
+[queen.drones.native-drone]
+max_concurrency = 4
+drone_timeout = "30m"
+stall_threshold = 120
+
 [creep]
 enabled = true
 

--- a/src/queen/src/actors/supervisor.rs
+++ b/src/queen/src/actors/supervisor.rs
@@ -12,7 +12,7 @@ use tokio::process::Child;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
-use crate::config::DroneTypeConfig;
+use crate::config::{DroneTypeConfig, EffectiveDroneConfig};
 use crate::messages::{SpawnRequest, StatusQuery, StatusResponse};
 use crate::notifier::{Notifier, QueenEvent};
 use nydus::NydusClient;
@@ -32,15 +32,15 @@ fn can_spawn(
     if active.len() as i32 >= max_concurrency {
         return false;
     }
-    if let Some(type_config) = drones.get(drone_type) {
-        if let Some(type_limit) = type_config.max_concurrency {
-            let type_count = active
-                .values()
-                .filter(|d| d.drone_type == drone_type)
-                .count() as i32;
-            if type_count >= type_limit {
-                return false;
-            }
+    if let Some(type_config) = drones.get(drone_type)
+        && let Some(type_limit) = type_config.max_concurrency
+    {
+        let type_count = active
+            .values()
+            .filter(|d| d.drone_type == drone_type)
+            .count() as i32;
+        if type_count >= type_limit {
+            return false;
         }
     }
     true
@@ -52,15 +52,16 @@ fn resolve_timeout_stall(
     default_timeout: Duration,
     default_stall: Duration,
 ) -> (Duration, Duration) {
-    let type_config = drones.get(drone_type);
-    let timeout = type_config
-        .and_then(|c| c.drone_timeout.as_ref())
-        .and_then(|t| crate::parse_duration(t).ok())
-        .unwrap_or(default_timeout);
-    let stall = type_config
-        .and_then(|c| c.stall_threshold)
-        .map(Duration::from_secs)
-        .unwrap_or(default_stall);
+    let effective = EffectiveDroneConfig::resolve(
+        drones,
+        drone_type,
+        // Convert default_timeout back to string for the resolver — it will be re-parsed.
+        // This round-trip is acceptable because the default was already validated at startup.
+        &format!("{}s", default_timeout.as_secs()),
+        default_stall.as_secs(),
+    );
+    let timeout = crate::parse_duration(&effective.drone_timeout).unwrap_or(default_timeout);
+    let stall = Duration::from_secs(effective.stall_threshold);
     (timeout, stall)
 }
 
@@ -757,4 +758,162 @@ async fn shutdown_all(client: &NydusClient, active: &mut HashMap<String, DroneHa
         }
     }
     // ShuttingDown notification is sent from main.rs only
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal DroneHandle stub for testing can_spawn().
+    /// Only `drone_type` matters for concurrency checks.
+    fn stub_handle(drone_type: &str) -> DroneHandle {
+        let (_proto_tx, protocol_rx) = mpsc::channel(1);
+        let (_stderr_tx, stderr_rx) = mpsc::channel(1);
+        // We need a real Child, but can_spawn only inspects the HashMap — it never
+        // touches the handle's process. Use a no-op `true` process.
+        let process = tokio::process::Command::new("true")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn `true`");
+        let now = Instant::now();
+        DroneHandle {
+            job_run_id: String::new(),
+            drone_type: drone_type.to_string(),
+            process,
+            started_at: now,
+            timeout: Duration::from_secs(3600),
+            last_activity: now,
+            stall_notified: false,
+            stall_threshold: Duration::from_secs(300),
+            protocol_rx,
+            stderr_rx,
+            stdin_tx: None,
+        }
+    }
+
+    #[test]
+    fn can_spawn_under_global_limit() {
+        let active = HashMap::new();
+        let drones = HashMap::new();
+        assert!(can_spawn(&active, 4, &drones, "claude-drone"));
+    }
+
+    #[tokio::test]
+    async fn can_spawn_at_global_limit() {
+        let mut active = HashMap::new();
+        for i in 0..4 {
+            active.insert(format!("run-{i}"), stub_handle("claude-drone"));
+        }
+        let drones = HashMap::new();
+        assert!(!can_spawn(&active, 4, &drones, "claude-drone"));
+    }
+
+    #[tokio::test]
+    async fn can_spawn_per_type_limit_blocks() {
+        let mut active = HashMap::new();
+        active.insert("run-0".into(), stub_handle("claude-drone"));
+        active.insert("run-1".into(), stub_handle("claude-drone"));
+        let mut drones = HashMap::new();
+        drones.insert(
+            "claude-drone".into(),
+            DroneTypeConfig {
+                max_concurrency: Some(2),
+                drone_timeout: None,
+                stall_threshold: None,
+            },
+        );
+        // Global limit (4) not reached, but per-type limit (2) is.
+        assert!(!can_spawn(&active, 4, &drones, "claude-drone"));
+    }
+
+    #[tokio::test]
+    async fn can_spawn_per_type_limit_allows_other_type() {
+        let mut active = HashMap::new();
+        active.insert("run-0".into(), stub_handle("claude-drone"));
+        active.insert("run-1".into(), stub_handle("claude-drone"));
+        let mut drones = HashMap::new();
+        drones.insert(
+            "claude-drone".into(),
+            DroneTypeConfig {
+                max_concurrency: Some(2),
+                drone_timeout: None,
+                stall_threshold: None,
+            },
+        );
+        // claude-drone at its limit, but native-drone can still spawn.
+        assert!(can_spawn(&active, 4, &drones, "native-drone"));
+    }
+
+    #[test]
+    fn can_spawn_unknown_type_uses_global_only() {
+        let active = HashMap::new();
+        let mut drones = HashMap::new();
+        drones.insert(
+            "claude-drone".into(),
+            DroneTypeConfig {
+                max_concurrency: Some(1),
+                drone_timeout: None,
+                stall_threshold: None,
+            },
+        );
+        // "unknown-drone" has no per-type config — only global limit applies.
+        assert!(can_spawn(&active, 4, &drones, "unknown-drone"));
+    }
+
+    #[test]
+    fn resolve_timeout_stall_uses_per_type_override() {
+        let mut drones = HashMap::new();
+        drones.insert(
+            "claude-drone".into(),
+            DroneTypeConfig {
+                max_concurrency: None,
+                drone_timeout: Some("4h".into()),
+                stall_threshold: Some(600),
+            },
+        );
+        let (timeout, stall) = resolve_timeout_stall(
+            &drones,
+            "claude-drone",
+            Duration::from_secs(7200),
+            Duration::from_secs(300),
+        );
+        assert_eq!(timeout, Duration::from_secs(4 * 3600));
+        assert_eq!(stall, Duration::from_secs(600));
+    }
+
+    #[test]
+    fn resolve_timeout_stall_falls_back_to_defaults() {
+        let drones = HashMap::new();
+        let (timeout, stall) = resolve_timeout_stall(
+            &drones,
+            "unknown-drone",
+            Duration::from_secs(7200),
+            Duration::from_secs(300),
+        );
+        assert_eq!(timeout, Duration::from_secs(7200));
+        assert_eq!(stall, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn resolve_timeout_stall_partial_override() {
+        let mut drones = HashMap::new();
+        drones.insert(
+            "claude-drone".into(),
+            DroneTypeConfig {
+                max_concurrency: None,
+                drone_timeout: Some("30m".into()),
+                stall_threshold: None, // falls back to default
+            },
+        );
+        let (timeout, stall) = resolve_timeout_stall(
+            &drones,
+            "claude-drone",
+            Duration::from_secs(7200),
+            Duration::from_secs(300),
+        );
+        assert_eq!(timeout, Duration::from_secs(30 * 60));
+        assert_eq!(stall, Duration::from_secs(300));
+    }
 }

--- a/src/queen/src/actors/supervisor.rs
+++ b/src/queen/src/actors/supervisor.rs
@@ -12,6 +12,7 @@ use tokio::process::Child;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
+use crate::config::DroneTypeConfig;
 use crate::messages::{SpawnRequest, StatusQuery, StatusResponse};
 use crate::notifier::{Notifier, QueenEvent};
 use nydus::NydusClient;
@@ -20,6 +21,47 @@ fn gzip_bytes(data: &[u8]) -> Vec<u8> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
     encoder.write_all(data).expect("gzip write failed");
     encoder.finish().expect("gzip finish failed")
+}
+
+fn can_spawn(
+    active: &HashMap<String, DroneHandle>,
+    max_concurrency: i32,
+    drones: &HashMap<String, DroneTypeConfig>,
+    drone_type: &str,
+) -> bool {
+    if active.len() as i32 >= max_concurrency {
+        return false;
+    }
+    if let Some(type_config) = drones.get(drone_type) {
+        if let Some(type_limit) = type_config.max_concurrency {
+            let type_count = active
+                .values()
+                .filter(|d| d.drone_type == drone_type)
+                .count() as i32;
+            if type_count >= type_limit {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn resolve_timeout_stall(
+    drones: &HashMap<String, DroneTypeConfig>,
+    drone_type: &str,
+    default_timeout: Duration,
+    default_stall: Duration,
+) -> (Duration, Duration) {
+    let type_config = drones.get(drone_type);
+    let timeout = type_config
+        .and_then(|c| c.drone_timeout.as_ref())
+        .and_then(|t| crate::parse_duration(t).ok())
+        .unwrap_or(default_timeout);
+    let stall = type_config
+        .and_then(|c| c.stall_threshold)
+        .map(Duration::from_secs)
+        .unwrap_or(default_stall);
+    (timeout, stall)
 }
 
 async fn store_session_artifact(client: &NydusClient, run_id: &str, session_b64: &str) {
@@ -54,6 +96,7 @@ struct DroneHandle {
     timeout: Duration,
     last_activity: Instant,
     stall_notified: bool,
+    stall_threshold: Duration,
     protocol_rx: mpsc::Receiver<DroneMessage>,
     stderr_rx: mpsc::Receiver<()>,
     stdin_tx: Option<mpsc::Sender<QueenMessage>>,
@@ -66,6 +109,7 @@ pub async fn run(
     max_concurrency: i32,
     default_timeout: Duration,
     stall_threshold: Duration,
+    drones: HashMap<String, DroneTypeConfig>,
     drone_dir: PathBuf,
     mut spawn_rx: mpsc::Receiver<SpawnRequest>,
     mut status_rx: mpsc::Receiver<(StatusQuery, oneshot::Sender<StatusResponse>)>,
@@ -80,10 +124,11 @@ pub async fn run(
 
         tokio::select! {
             Some(request) = spawn_rx.recv() => {
-                if (active.len() as i32) < max_concurrency {
-                    spawn_drone(&client, &notifier, &mut active, request, default_timeout, &drone_dir).await;
+                if can_spawn(&active, max_concurrency, &drones, &request.drone_type) {
+                    let (timeout, stall) = resolve_timeout_stall(&drones, &request.drone_type, default_timeout, stall_threshold);
+                    spawn_drone(&client, &notifier, &mut active, request, timeout, stall, &drone_dir).await;
                 } else {
-                    tracing::info!(job_run_id = %request.job_run_id, "concurrency limit reached, queueing");
+                    tracing::info!(job_run_id = %request.job_run_id, drone_type = %request.drone_type, "concurrency limit reached, queueing");
                     queue.push_back(request);
                 }
             }
@@ -96,13 +141,21 @@ pub async fn run(
             }
 
             _ = health_ticker.tick() => {
-                check_drones(&client, &notifier, &mut active, stall_threshold).await;
+                check_drones(&client, &notifier, &mut active).await;
 
-                while (active.len() as i32) < max_concurrency {
-                    if let Some(request) = queue.pop_front() {
-                        spawn_drone(&client, &notifier, &mut active, request, default_timeout, &drone_dir).await;
-                    } else {
-                        break;
+                {
+                    let mut i = 0;
+                    while i < queue.len() {
+                        if !can_spawn(&active, max_concurrency, &drones, &queue[i].drone_type) {
+                            i += 1;
+                            continue;
+                        }
+                        let request = queue.remove(i).unwrap();
+                        let (timeout, stall) = resolve_timeout_stall(&drones, &request.drone_type, default_timeout, stall_threshold);
+                        spawn_drone(&client, &notifier, &mut active, request, timeout, stall, &drone_dir).await;
+                        if active.len() as i32 >= max_concurrency {
+                            break;
+                        }
                     }
                 }
             }
@@ -128,6 +181,7 @@ async fn spawn_drone(
     active: &mut HashMap<String, DroneHandle>,
     request: SpawnRequest,
     default_timeout: Duration,
+    stall_threshold: Duration,
     drone_dir: &Path,
 ) {
     tracing::info!(job_run_id = %request.job_run_id, drone_type = %request.drone_type, "spawning drone");
@@ -307,6 +361,7 @@ async fn spawn_drone(
         timeout: default_timeout,
         last_activity: now,
         stall_notified: false,
+        stall_threshold,
         protocol_rx,
         stderr_rx,
         stdin_tx: Some(stdin_tx),
@@ -508,7 +563,6 @@ async fn check_drones(
     client: &NydusClient,
     notifier: &Arc<dyn Notifier>,
     active: &mut HashMap<String, DroneHandle>,
-    stall_threshold: Duration,
 ) {
     let now = Instant::now();
     let mut completed = Vec::new();
@@ -672,7 +726,9 @@ async fn check_drones(
         }
 
         // Check stall (based on protocol + stderr activity)
-        if now.duration_since(handle.last_activity) > stall_threshold && !handle.stall_notified {
+        if now.duration_since(handle.last_activity) > handle.stall_threshold
+            && !handle.stall_notified
+        {
             handle.stall_notified = true;
             notifier
                 .notify(QueenEvent::DroneStalled {

--- a/src/queen/src/config.rs
+++ b/src/queen/src/config.rs
@@ -305,6 +305,29 @@ impl Config {
                 }
             }
         }
+        for (name, drone_config) in &self.queen.drones {
+            if let Some(max) = drone_config.max_concurrency {
+                if max <= 0 {
+                    anyhow::bail!(
+                        "queen.drones.{name}.max_concurrency must be greater than 0"
+                    );
+                }
+            }
+            if let Some(ref timeout) = drone_config.drone_timeout {
+                if crate::parse_duration(timeout).is_err() {
+                    anyhow::bail!(
+                        "queen.drones.{name}.drone_timeout '{timeout}' is not a valid duration"
+                    );
+                }
+            }
+            if let Some(stall) = drone_config.stall_threshold {
+                if stall == 0 {
+                    anyhow::bail!(
+                        "queen.drones.{name}.stall_threshold must be greater than 0"
+                    );
+                }
+            }
+        }
         Ok(())
     }
 
@@ -678,4 +701,142 @@ language_id = "typescript"
         assert_eq!(ts.language_id, "typescript");
     }
 
+    #[test]
+    fn test_validate_drone_type_zero_concurrency() {
+        let f = write_toml(
+            r#"
+[queen]
+name = "test"
+
+[queen.drones.bad-drone]
+max_concurrency = 0
+"#,
+        );
+        let err = Config::load(f.path()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("queen.drones.bad-drone.max_concurrency must be greater than 0")
+        );
+    }
+
+    #[test]
+    fn test_validate_drone_type_invalid_timeout() {
+        let f = write_toml(
+            r#"
+[queen]
+name = "test"
+
+[queen.drones.bad-drone]
+drone_timeout = "not-valid"
+"#,
+        );
+        let err = Config::load(f.path()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("queen.drones.bad-drone.drone_timeout 'not-valid' is not a valid duration")
+        );
+    }
+
+    #[test]
+    fn test_validate_drone_type_zero_stall() {
+        let f = write_toml(
+            r#"
+[queen]
+name = "test"
+
+[queen.drones.bad-drone]
+stall_threshold = 0
+"#,
+        );
+        let err = Config::load(f.path()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("queen.drones.bad-drone.stall_threshold must be greater than 0")
+        );
+    }
+
+    #[test]
+    fn test_parse_drone_type_config() {
+        let f = write_toml(
+            r#"
+[queen]
+name = "test"
+
+[queen.drones.claude-drone]
+max_concurrency = 2
+drone_timeout = "2h"
+stall_threshold = 300
+
+[queen.drones.native-drone]
+max_concurrency = 4
+drone_timeout = "30m"
+stall_threshold = 120
+"#,
+        );
+        let config = Config::load(f.path()).unwrap();
+        assert_eq!(config.queen.drones.len(), 2);
+
+        let claude = &config.queen.drones["claude-drone"];
+        assert_eq!(claude.max_concurrency, Some(2));
+        assert_eq!(claude.drone_timeout.as_deref(), Some("2h"));
+        assert_eq!(claude.stall_threshold, Some(300));
+
+        let native = &config.queen.drones["native-drone"];
+        assert_eq!(native.max_concurrency, Some(4));
+        assert_eq!(native.drone_timeout.as_deref(), Some("30m"));
+        assert_eq!(native.stall_threshold, Some(120));
+    }
+
+    #[test]
+    fn test_effective_drone_config_with_overrides() {
+        let f = write_toml(
+            r#"
+[queen]
+name = "test"
+drone_timeout = "2h"
+stall_threshold = 300
+
+[queen.drones.claude-drone]
+max_concurrency = 2
+drone_timeout = "4h"
+"#,
+        );
+        let config = Config::load(f.path()).unwrap();
+        let effective = config.queen.effective_drone_config("claude-drone");
+
+        assert_eq!(effective.max_concurrency, Some(2));
+        assert_eq!(effective.drone_timeout, "4h");
+        // stall_threshold not overridden — falls back to global
+        assert_eq!(effective.stall_threshold, 300);
+    }
+
+    #[test]
+    fn test_effective_drone_config_unknown_type() {
+        let f = write_toml(
+            r#"
+[queen]
+name = "test"
+drone_timeout = "2h"
+stall_threshold = 300
+"#,
+        );
+        let config = Config::load(f.path()).unwrap();
+        let effective = config.queen.effective_drone_config("unknown-drone");
+
+        assert!(effective.max_concurrency.is_none());
+        assert_eq!(effective.drone_timeout, "2h");
+        assert_eq!(effective.stall_threshold, 300);
+    }
+
+    #[test]
+    fn test_drones_field_defaults_to_empty() {
+        let f = write_toml(
+            r#"
+[queen]
+name = "test"
+"#,
+        );
+        let config = Config::load(f.path()).unwrap();
+        assert!(config.queen.drones.is_empty());
+    }
 }

--- a/src/queen/src/config.rs
+++ b/src/queen/src/config.rs
@@ -96,6 +96,44 @@ pub struct QueenConfig {
     pub drone_dir: String,
     /// Default repo_url injected into jobs that don't specify one.
     pub default_repo_url: Option<String>,
+    /// Per-drone-type configuration, keyed by drone binary name.
+    #[serde(default)]
+    pub drones: HashMap<String, DroneTypeConfig>,
+}
+
+/// Per-drone-type configuration. All fields are optional — omitted values
+/// fall back to the corresponding global `queen.*` setting.
+#[derive(Debug, Deserialize, Clone)]
+pub struct DroneTypeConfig {
+    pub max_concurrency: Option<i32>,
+    pub drone_timeout: Option<String>,
+    pub stall_threshold: Option<u64>,
+}
+
+/// Resolved drone config with global fallbacks applied.
+#[derive(Debug, Clone)]
+pub struct EffectiveDroneConfig {
+    /// `None` means no per-type limit — only the global limit applies.
+    pub max_concurrency: Option<i32>,
+    pub drone_timeout: String,
+    pub stall_threshold: u64,
+}
+
+impl QueenConfig {
+    /// Resolve effective config for a drone type.
+    /// Per-type values override globals; missing per-type values use globals.
+    pub fn effective_drone_config(&self, drone_type: &str) -> EffectiveDroneConfig {
+        let type_config = self.drones.get(drone_type);
+        EffectiveDroneConfig {
+            max_concurrency: type_config.and_then(|c| c.max_concurrency),
+            drone_timeout: type_config
+                .and_then(|c| c.drone_timeout.clone())
+                .unwrap_or_else(|| self.drone_timeout.clone()),
+            stall_threshold: type_config
+                .and_then(|c| c.stall_threshold)
+                .unwrap_or(self.stall_threshold),
+        }
+    }
 }
 
 /// Configuration for a single LSP server within hatchery.toml.
@@ -639,4 +677,5 @@ language_id = "typescript"
         assert_eq!(ts.extensions, vec![".ts", ".tsx"]);
         assert_eq!(ts.language_id, "typescript");
     }
+
 }

--- a/src/queen/src/config.rs
+++ b/src/queen/src/config.rs
@@ -308,9 +308,7 @@ impl Config {
         for (name, drone_config) in &self.queen.drones {
             if let Some(max) = drone_config.max_concurrency {
                 if max <= 0 {
-                    anyhow::bail!(
-                        "queen.drones.{name}.max_concurrency must be greater than 0"
-                    );
+                    anyhow::bail!("queen.drones.{name}.max_concurrency must be greater than 0");
                 }
             }
             if let Some(ref timeout) = drone_config.drone_timeout {
@@ -322,9 +320,7 @@ impl Config {
             }
             if let Some(stall) = drone_config.stall_threshold {
                 if stall == 0 {
-                    anyhow::bail!(
-                        "queen.drones.{name}.stall_threshold must be greater than 0"
-                    );
+                    anyhow::bail!("queen.drones.{name}.stall_threshold must be greater than 0");
                 }
             }
         }
@@ -732,8 +728,9 @@ drone_timeout = "not-valid"
         );
         let err = Config::load(f.path()).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("queen.drones.bad-drone.drone_timeout 'not-valid' is not a valid duration")
+            err.to_string().contains(
+                "queen.drones.bad-drone.drone_timeout 'not-valid' is not a valid duration"
+            )
         );
     }
 

--- a/src/queen/src/config.rs
+++ b/src/queen/src/config.rs
@@ -119,20 +119,38 @@ pub struct EffectiveDroneConfig {
     pub stall_threshold: u64,
 }
 
+impl EffectiveDroneConfig {
+    /// Resolve effective config for a drone type from the per-type map and global defaults.
+    /// This is the single resolution path used by both `QueenConfig` and the supervisor.
+    pub fn resolve(
+        drones: &HashMap<String, DroneTypeConfig>,
+        drone_type: &str,
+        default_timeout: &str,
+        default_stall: u64,
+    ) -> Self {
+        let type_config = drones.get(drone_type);
+        Self {
+            max_concurrency: type_config.and_then(|c| c.max_concurrency),
+            drone_timeout: type_config
+                .and_then(|c| c.drone_timeout.clone())
+                .unwrap_or_else(|| default_timeout.to_string()),
+            stall_threshold: type_config
+                .and_then(|c| c.stall_threshold)
+                .unwrap_or(default_stall),
+        }
+    }
+}
+
 impl QueenConfig {
     /// Resolve effective config for a drone type.
     /// Per-type values override globals; missing per-type values use globals.
     pub fn effective_drone_config(&self, drone_type: &str) -> EffectiveDroneConfig {
-        let type_config = self.drones.get(drone_type);
-        EffectiveDroneConfig {
-            max_concurrency: type_config.and_then(|c| c.max_concurrency),
-            drone_timeout: type_config
-                .and_then(|c| c.drone_timeout.clone())
-                .unwrap_or_else(|| self.drone_timeout.clone()),
-            stall_threshold: type_config
-                .and_then(|c| c.stall_threshold)
-                .unwrap_or(self.stall_threshold),
-        }
+        EffectiveDroneConfig::resolve(
+            &self.drones,
+            drone_type,
+            &self.drone_timeout,
+            self.stall_threshold,
+        )
     }
 }
 
@@ -310,18 +328,25 @@ impl Config {
                 if max <= 0 {
                     anyhow::bail!("queen.drones.{name}.max_concurrency must be greater than 0");
                 }
-            }
-            if let Some(ref timeout) = drone_config.drone_timeout {
-                if crate::parse_duration(timeout).is_err() {
-                    anyhow::bail!(
-                        "queen.drones.{name}.drone_timeout '{timeout}' is not a valid duration"
+                if max > self.queen.max_concurrency {
+                    tracing::warn!(
+                        "queen.drones.{name}.max_concurrency ({max}) exceeds \
+                         queen.max_concurrency ({}); the global limit will cap it at runtime",
+                        self.queen.max_concurrency
                     );
                 }
             }
-            if let Some(stall) = drone_config.stall_threshold {
-                if stall == 0 {
-                    anyhow::bail!("queen.drones.{name}.stall_threshold must be greater than 0");
-                }
+            if let Some(ref timeout) = drone_config.drone_timeout
+                && crate::parse_duration(timeout).is_err()
+            {
+                anyhow::bail!(
+                    "queen.drones.{name}.drone_timeout '{timeout}' is not a valid duration"
+                );
+            }
+            if let Some(stall) = drone_config.stall_threshold
+                && stall == 0
+            {
+                anyhow::bail!("queen.drones.{name}.stall_threshold must be greater than 0");
             }
         }
         Ok(())

--- a/src/queen/src/main.rs
+++ b/src/queen/src/main.rs
@@ -106,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
     let supervisor_notifier = notifier.clone();
     let max_concurrency = config.queen.max_concurrency;
     let drone_dir = PathBuf::from(&config.queen.drone_dir);
+    let drones = config.queen.drones.clone();
     let supervisor_token = token.clone();
     let supervisor_handle = tokio::spawn(async move {
         actors::supervisor::run(
@@ -114,6 +115,7 @@ async fn main() -> anyhow::Result<()> {
             max_concurrency,
             default_timeout,
             stall_threshold,
+            drones,
             drone_dir,
             spawn_rx,
             status_query_rx,


### PR DESCRIPTION
## Summary
- Add `DroneTypeConfig` and `EffectiveDroneConfig` structs to support per-drone-type configuration via `[queen.drones.<type>]` TOML tables
- Add validation for per-type `max_concurrency`, `drone_timeout`, and `stall_threshold` fields
- Update Supervisor spawn gate to check both global and per-type concurrency limits, with indexed queue draining that skips type-blocked items to prevent head-of-line blocking
- Store `stall_threshold` per `DroneHandle` (resolved from per-type config with global fallback)
- Wire `drones` config from `main.rs` through to supervisor
- Add example `[queen.drones.claude-drone]` and `[queen.drones.native-drone]` sections to `hatchery.toml`

## Test plan
- [x] 7 new unit tests for config parsing, resolver, and validation (47 total pass)
- [x] `buck2 build root//src/queen:queen` succeeds
- [x] `buck2 build 'root//src/queen:queen[clippy.txt]'` clean (no warnings)
- [x] `buck2 test root//src/queen:queen-test` — all 47 tests pass
- [x] Pre-push hooks pass (build, test, clippy, rustfmt, abathur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)